### PR TITLE
docs: add reference credits to minuet-ai.nvim.

### DIFF
--- a/lua/llm/common/completion/frontends/blink.lua
+++ b/lua/llm/common/completion/frontends/blink.lua
@@ -1,3 +1,4 @@
+-- referenced from minuet-ai.nvim: https://github.com/milanglacier/minuet-ai.nvim
 local state = require("llm.state")
 local LOG = require("llm.common.log")
 local utils = require("llm.common.completion.utils")

--- a/lua/llm/common/completion/frontends/cmp.lua
+++ b/lua/llm/common/completion/frontends/cmp.lua
@@ -1,3 +1,4 @@
+-- referenced from minuet-ai.nvim: https://github.com/milanglacier/minuet-ai.nvim
 local ncmp = {}
 local state = require("llm.state")
 local LOG = require("llm.common.log")

--- a/lua/llm/common/completion/frontends/virtual_text.lua
+++ b/lua/llm/common/completion/frontends/virtual_text.lua
@@ -1,3 +1,4 @@
+-- referenced from minuet-ai.nvim: https://github.com/milanglacier/minuet-ai.nvim
 local state = require("llm.state")
 local LOG = require("llm.common.log")
 

--- a/lua/llm/common/completion/utils.lua
+++ b/lua/llm/common/completion/utils.lua
@@ -1,3 +1,7 @@
+-- This file uses code from minuet-ai.nvim
+-- Source: https://github.com/milanglacier/minuet-ai.nvim
+-- License: GNU General Public License v3.0
+-- Copyright (c) minuet-ai.nvim contributors
 local state = require("llm.state")
 local LOG = require("llm.common.log")
 local uv = vim.uv or vim.loop


### PR DESCRIPTION
Hi, I noticed that llm.nvim incorporates significant portions of code from minuet-ai.nvim. 

Since both projects are licensed under GPLv3, so you can use my code with no problem. The license requires attribution for borrowed code though.

This PR adds the necessary attribution comments to the completion-related files that were referenced from the minuet-ai.nvim project to ensure compliance with GPLv3 requirements. Thank you.
