### PR TITLE
refactor: standardize function naming conventions

### DIFF
--- a/lua/llm/backends/openai.lua
+++ b/lua/llm/backends/openai.lua
@@ -11,7 +11,7 @@ function openai.StreamingHandler(chunk, ctx)
     ctx.line = ctx.line .. chunk
   else
     ctx.line = ctx.line .. chunk
-    ctx.line = F.trim_leading_whitespace(ctx.line)
+    ctx.line = F.TrimLeadingWhitespace(ctx.line)
     local start_idx = ctx.line:find("data: ", 1, true)
     local end_idx = ctx.line:find("}]", 1, true)
     local json_str = nil

--- a/lua/llm/common/api.lua
+++ b/lua/llm/common/api.lua
@@ -78,7 +78,7 @@ local function display_sub(s, i, j)
   return s:sub(start, stop)
 end
 
-function api.trim_leading_whitespace(str)
+function api.TrimLeadingWhitespace(str)
   if str == nil then
     return ""
   end
@@ -265,7 +265,7 @@ function api.GetVisualSelection(lines)
   return seletion
 end
 
-function api.make_inline_context(opts, bufnr, name)
+function api.MakeInlineContext(opts, bufnr, name)
   local lines, start_line, start_col, end_line, end_col
 
   local mode = opts.mode or vim.fn.mode()
@@ -308,7 +308,7 @@ end
 
 function api.GetAttach(opts)
   local bufnr = vim.api.nvim_get_current_buf()
-  local lines = api.make_inline_context(opts, bufnr, "attach_to_chat")
+  local lines = api.MakeInlineContext(opts, bufnr, "attach_to_chat")
   api.VisMode2NorMode()
 
   if opts.is_codeblock and not vim.tbl_isempty(lines) then
@@ -329,7 +329,7 @@ function api.ClearAttach()
   state.input.attach_content = nil
 end
 
-function api.update_prompt(name)
+function api.UpdatePrompt(name)
   if state.summarize_suggestions.prompt and not state.summarize_suggestions.status then
     if state.session[name][1].role == "system" then
       state.session[name][1].content =
@@ -341,7 +341,7 @@ function api.update_prompt(name)
   end
 end
 
-function api.reset_prompt()
+function api.ResetPrompt()
   if state.summarize_suggestions.status then
     if state.session[state.session.filename][1].role == "system" then
       state.session[state.session.filename][1].content = conf.configs.prompt
@@ -354,7 +354,7 @@ end
 function api.ClearSummarizeSuggestions()
   state.summarize_suggestions.ctx = nil
   state.summarize_suggestions.pattern = nil
-  api.reset_prompt()
+  api.ResetPrompt()
   state.summarize_suggestions.status = false
 end
 
@@ -637,7 +637,7 @@ function api.ScrollWindow(winid, direction)
   end)
 end
 
-function api.get_chat_ui_bufnr_list()
+function api.GetChatUiBufnrList()
   if conf.configs.style == "float" then
     return { state.input.popup.bufnr, state.llm.popup.bufnr }
   else

--- a/lua/llm/common/io/parse.lua
+++ b/lua/llm/common/io/parse.lua
@@ -153,7 +153,7 @@ function io_parse.GetOutput(opts)
       command = "curl",
       args = _args,
       on_stdout = vim.schedule_wrap(function(_, data)
-        local str = api.trim_leading_whitespace(data)
+        local str = api.TrimLeadingWhitespace(data)
         local prefix = str:sub(1, 1)
         if prefix ~= "{" then
           if prefix ~= "" then

--- a/lua/llm/session.lua
+++ b/lua/llm/session.lua
@@ -66,7 +66,7 @@ end
 
 function M.LLMSelectedTextHandler(description, builtin_called, opts)
   opts = opts or {}
-  local lines = F.make_inline_context(opts, vim.api.nvim_get_current_buf(), "disposable_ask")
+  local lines = F.MakeInlineContext(opts, vim.api.nvim_get_current_buf(), "disposable_ask")
   local content = F.GetVisualSelection(lines)
 
   if builtin_called then
@@ -107,7 +107,7 @@ function M.LLMSelectedTextHandler(description, builtin_called, opts)
       state.session[state.popwin.winid] = {}
     end
     table.insert(state.session[state.popwin.winid], { role = "user", content = description .. "\n" .. content .. "\n" })
-    F.update_prompt(state.popwin.winid)
+    F.UpdatePrompt(state.popwin.winid)
 
     for _, k in ipairs({ "display", "copy_suggestion_code" }) do
       utils.set_keymapping(opts._[k].mapping.mode, opts._[k].mapping.keys, function()
@@ -263,7 +263,7 @@ function M.NewSession()
               end
             end
             vim.api.nvim_buf_set_lines(state.input.popup.bufnr, 0, -1, false, {})
-            F.update_prompt(state.session.filename)
+            F.UpdatePrompt(state.session.filename)
             if input ~= "" then
               table.insert(state.session[state.session.filename], { role = "user", content = input })
               F.SetRole(bufnr, winid, "user")
@@ -356,7 +356,7 @@ function M.NewSession()
                     end
                     state.input.popup:unmount()
                     state.input.popup = nil
-                    F.update_prompt(state.session.filename)
+                    F.UpdatePrompt(state.session.filename)
                     if input ~= "" then
                       table.insert(state.session[state.session.filename], { role = "user", content = input })
                       F.SetRole(bufnr, winid, "user")

--- a/lua/llm/tools/attach_to_chat.lua
+++ b/lua/llm/tools/attach_to_chat.lua
@@ -109,7 +109,7 @@ function M.handler(_, _, _, _, _, opts)
     sess.NewSession()
   end
 
-  local bufnr_list = F.get_chat_ui_bufnr_list()
+  local bufnr_list = F.GetChatUiBufnrList()
   for _, ui_bufnr in ipairs(bufnr_list) do
     for _, k in ipairs({ "display", "copy_suggestion_code" }) do
       utils.set_keymapping(options[k].mapping.mode, options[k].mapping.keys, function()


### PR DESCRIPTION
- Change function names to match PascalCase style

- Update trim_leading_whitespace to TrimLeadingWhitespace

- Update make_inline_context to MakeInlineContext

- Update update_prompt to UpdatePrompt

- Update reset_prompt to ResetPrompt

- Update get_chat_ui_bufnr_list to GetChatUiBufnrList