### PR TITLE
feat: add Bearer authorization to ollama completion

### DIFF
--- a/lua/llm/common/completion/backends/ollama.lua
+++ b/lua/llm/common/completion/backends/ollama.lua
@@ -44,6 +44,11 @@ function ollama.request(opts)
   if opts.keep_alive then
     body["keep_alive"] = opts.keep_alive
   end
+  if opts.fetch_key ~= nil then
+    LLM_KEY = opts.fetch_key()
+  end
+
+  local authorization = "Authorization: Bearer " .. LLM_KEY
 
   local _args = {
     "-L",
@@ -54,6 +59,8 @@ function ollama.request(opts)
     "POST",
     "-H",
     "Content-Type: application/json",
+    "-H",
+    authorization,
     "--max-time",
     opts.timeout,
     "-d",

--- a/lua/llm/common/completion/backends/ollama.lua
+++ b/lua/llm/common/completion/backends/ollama.lua
@@ -44,6 +44,8 @@ function ollama.request(opts)
   if opts.keep_alive then
     body["keep_alive"] = opts.keep_alive
   end
+
+  local LLM_KEY = vim.env.LLM_KEY or ""
   if opts.fetch_key ~= nil then
     LLM_KEY = opts.fetch_key()
   end


### PR DESCRIPTION
Great plugin, thanks!

I couldn't use ollama remotely for completion, after some debugging I realized that you're not using the LLM_KEY in the curl request for Bearer authorization. I've added this to the ollama backend and it works great now.