### PR TITLE
fix: wrap on_stderr callbacks with vim.schedule_wrap

### DIFF
--- a/lua/llm/common/io/parse.lua
+++ b/lua/llm/common/io/parse.lua
@@ -190,12 +190,12 @@ function io_parse.GetOutput(opts)
           backends.get_tools_respond(required_params.api_type, conf.configs, ctx)(data)
         end
       end),
-      on_stderr = function(_, err)
+      on_stderr = vim.schedule_wrap(function(_, err)
         if err ~= nil then
           LOG:ERROR(err)
         end
         -- TODO: Add error handling
-      end,
+      end),
       on_exit = vim.schedule_wrap(function()
         if ctx.body.tools ~= nil and F.IsValid(backends.msg_tool_calls_content) then
           ctx.callback = function()

--- a/lua/llm/common/io/streaming.lua
+++ b/lua/llm/common/io/streaming.lua
@@ -226,12 +226,12 @@ function M.GetStreamingOutput(opts)
       end
       -- TODO: Add stdout handling
     end),
-    on_stderr = function(_, err)
+    on_stderr = vim.schedule_wrap(function(_, err)
       if err ~= nil then
         LOG:ERROR(err)
       end
       -- TODO: Add error handling
-    end,
+    end),
     on_exit = vim.schedule_wrap(function()
       if ctx.body.tools ~= nil and F.IsValid(backends.msg_tool_calls_content) then
         ctx.callback = function()


### PR DESCRIPTION
- Ensure error logging is scheduled correctly

- Consistency across io_parse and streaming modules