### PR TITLE
fix: win_highlight of history and models window

### DIFF
--- a/lua/llm/common/api.lua
+++ b/lua/llm/common/api.lua
@@ -707,7 +707,7 @@ function api.SetItemHl(popup, hl)
   vim.api.nvim_buf_clear_namespace(popup.bufnr, ns, 0, count)
 
   api.AddHighlight(ns, popup.bufnr, "LlmGrayLight", 0, 0, count, -1)
-  api.AddHighlight(ns, popup.bufnr, hl, idx - 1, 0, idx - 1, -1)
+  api.AddHighlight(ns, popup.bufnr, "LlmSelection", idx - 1, 0, idx - 1, -1)
 end
 
 function api.HistoryPreview(layout_opts, opts)

--- a/lua/llm/common/api.lua
+++ b/lua/llm/common/api.lua
@@ -707,7 +707,16 @@ function api.SetItemHl(popup, hl)
   vim.api.nvim_buf_clear_namespace(popup.bufnr, ns, 0, count)
 
   api.AddHighlight(ns, popup.bufnr, "LlmGrayLight", 0, 0, count, -1)
-  api.AddHighlight(ns, popup.bufnr, "LlmSelection", idx - 1, 0, idx - 1, -1)
+  api.AddHighlight(ns, popup.bufnr, hl, idx - 1, 0, idx - 1, -1)
+end
+
+---@param hl string
+---@param win_name string
+function api.FormatHl(hl, win_name)
+  local bg = vim.api.nvim_get_hl(0, { name = "CursorLine" }).bg
+  local fg = vim.api.nvim_get_hl(0, { name = hl }).fg
+  state[win_name].hl = ("Llm%sSelected"):format(string.gsub(win_name, "^%a", string.upper))
+  vim.api.nvim_set_hl(0, state[win_name].hl, { fg = fg, bg = bg })
 end
 
 function api.HistoryPreview(layout_opts, opts)

--- a/lua/llm/common/layout.lua
+++ b/lua/llm/common/layout.lua
@@ -80,6 +80,7 @@ function _layout.chat_ui(layout_opts, popup_input_opts, popup_output_opts, popup
     if not state.history.hl then
       state.history.hl = other.win_options.winhighlight:match(":(.-),")
       other.win_options.winhighlight = other.win_options.winhighlight:gsub(":(.-),", ":LlmGrayLight,")
+      F.FormatHl(state.history.hl, "history")
     end
     state.history.popup = Menu({
       enter = other.enter,
@@ -133,6 +134,7 @@ function _layout.chat_ui(layout_opts, popup_input_opts, popup_output_opts, popup
       if not state.models.hl then
         state.models.hl = models.win_options.winhighlight:match(":(.-),")
         models.win_options.winhighlight = models.win_options.winhighlight:gsub(":(.-),", ":LlmGrayLight,")
+        F.FormatHl(state.models.hl, "models")
       end
       state.models.popup = Menu({
         enter = models.enter,

--- a/plugin/llm.lua
+++ b/plugin/llm.lua
@@ -4,20 +4,24 @@ local streaming = require("llm.common.io.streaming")
 local app = require("llm.app")
 local F = require("llm.common.api")
 
+local cursorline_hl = vim.api.nvim_get_hl(0, { name = "CursorLine" })
+local cursorline_bg = cursorline_hl.bg
+
 local highlight = {
-  LlmBlueNormal = { fg = "#65bcff", bg = "NONE" },
-  LlmBlueLight = { fg = "#b0e2ff", bg = "NONE" },
-  LlmRedNormal = { fg = "#ff7eb9", bg = "NONE" },
-  LlmRedLight = { fg = "#fca7ea", bg = "NONE" },
-  LlmGreenNormal = { fg = "#4fd6be", bg = "NONE" },
-  LlmGreenLight = { fg = "#b8db87", bg = "NONE" },
-  LlmYellowNormal = { fg = "#ff966c", bg = "NONE" },
-  LlmYellowLight = { fg = "#f9e2af", bg = "NONE" },
-  LlmGrayNormal = { fg = "#828bb8", bg = "NONE" },
-  LlmGrayLight = { fg = "#9c9c9c", bg = "NONE" },
-  LlmPurpleNormal = { fg = "#c099ff", bg = "NONE" },
-  LlmPurpleLight = { fg = "#ee82ee", bg = "NONE" },
-  LlmWhiteNormal = { fg = "#c8d3f5", bg = "NONE" },
+  LlmBlueNormal = { fg = "#65bcff", bg = "NONE", default = true },
+  LlmBlueLight = { fg = "#b0e2ff", bg = "NONE", default = true },
+  LlmRedNormal = { fg = "#ff7eb9", bg = "NONE", default = true },
+  LlmRedLight = { fg = "#fca7ea", bg = "NONE", default = true },
+  LlmGreenNormal = { fg = "#4fd6be", bg = "NONE", default = true },
+  LlmGreenLight = { fg = "#b8db87", bg = "NONE", default = true },
+  LlmYellowNormal = { fg = "#ff966c", bg = "NONE", default = true },
+  LlmYellowLight = { fg = "#f9e2af", bg = "NONE", default = true },
+  LlmGrayNormal = { fg = "#828bb8", bg = "NONE", default = true },
+  LlmGrayLight = { fg = "#9c9c9c", bg = "NONE", default = true },
+  LlmSelection = { bg = cursorline_bg, default = true },
+  LlmPurpleNormal = { fg = "#c099ff", bg = "NONE", default = true },
+  LlmPurpleLight = { fg = "#ee82ee", bg = "NONE", default = true },
+  LlmWhiteNormal = { fg = "#c8d3f5", bg = "NONE", default = true },
 }
 
 local llm_augroup = vim.api.nvim_create_augroup("llm_augroup", { clear = true })

--- a/plugin/llm.lua
+++ b/plugin/llm.lua
@@ -5,19 +5,19 @@ local app = require("llm.app")
 local F = require("llm.common.api")
 
 local highlight = {
-  LlmBlueNormal = { fg = "#65bcff", bg = "NONE" },
-  LlmBlueLight = { fg = "#b0e2ff", bg = "NONE" },
-  LlmRedNormal = { fg = "#ff7eb9", bg = "NONE" },
-  LlmRedLight = { fg = "#fca7ea", bg = "NONE" },
-  LlmGreenNormal = { fg = "#4fd6be", bg = "NONE" },
-  LlmGreenLight = { fg = "#b8db87", bg = "NONE" },
-  LlmYellowNormal = { fg = "#ff966c", bg = "NONE" },
-  LlmYellowLight = { fg = "#f9e2af", bg = "NONE" },
-  LlmGrayNormal = { fg = "#828bb8", bg = "NONE" },
-  LlmGrayLight = { fg = "#9c9c9c", bg = "NONE" },
-  LlmPurpleNormal = { fg = "#c099ff", bg = "NONE" },
-  LlmPurpleLight = { fg = "#ee82ee", bg = "NONE" },
-  LlmWhiteNormal = { fg = "#c8d3f5", bg = "NONE" },
+  LlmBlueNormal = { fg = "#65bcff", bg = "NONE", default = true },
+  LlmBlueLight = { fg = "#b0e2ff", bg = "NONE", default = true },
+  LlmRedNormal = { fg = "#ff7eb9", bg = "NONE", default = true },
+  LlmRedLight = { fg = "#fca7ea", bg = "NONE", default = true },
+  LlmGreenNormal = { fg = "#4fd6be", bg = "NONE", default = true },
+  LlmGreenLight = { fg = "#b8db87", bg = "NONE", default = true },
+  LlmYellowNormal = { fg = "#ff966c", bg = "NONE", default = true },
+  LlmYellowLight = { fg = "#f9e2af", bg = "NONE", default = true },
+  LlmGrayNormal = { fg = "#828bb8", bg = "NONE", default = true },
+  LlmGrayLight = { fg = "#9c9c9c", bg = "NONE", default = true },
+  LlmPurpleNormal = { fg = "#c099ff", bg = "NONE", default = true },
+  LlmPurpleLight = { fg = "#ee82ee", bg = "NONE", default = true },
+  LlmWhiteNormal = { fg = "#c8d3f5", bg = "NONE", default = true },
 }
 
 local llm_augroup = vim.api.nvim_create_augroup("llm_augroup", { clear = true })

--- a/plugin/llm.lua
+++ b/plugin/llm.lua
@@ -4,24 +4,20 @@ local streaming = require("llm.common.io.streaming")
 local app = require("llm.app")
 local F = require("llm.common.api")
 
-local cursorline_hl = vim.api.nvim_get_hl(0, { name = "CursorLine" })
-local cursorline_bg = cursorline_hl.bg
-
 local highlight = {
-  LlmBlueNormal = { fg = "#65bcff", bg = "NONE", default = true },
-  LlmBlueLight = { fg = "#b0e2ff", bg = "NONE", default = true },
-  LlmRedNormal = { fg = "#ff7eb9", bg = "NONE", default = true },
-  LlmRedLight = { fg = "#fca7ea", bg = "NONE", default = true },
-  LlmGreenNormal = { fg = "#4fd6be", bg = "NONE", default = true },
-  LlmGreenLight = { fg = "#b8db87", bg = "NONE", default = true },
-  LlmYellowNormal = { fg = "#ff966c", bg = "NONE", default = true },
-  LlmYellowLight = { fg = "#f9e2af", bg = "NONE", default = true },
-  LlmGrayNormal = { fg = "#828bb8", bg = "NONE", default = true },
-  LlmGrayLight = { fg = "#9c9c9c", bg = "NONE", default = true },
-  LlmSelection = { bg = cursorline_bg, default = true },
-  LlmPurpleNormal = { fg = "#c099ff", bg = "NONE", default = true },
-  LlmPurpleLight = { fg = "#ee82ee", bg = "NONE", default = true },
-  LlmWhiteNormal = { fg = "#c8d3f5", bg = "NONE", default = true },
+  LlmBlueNormal = { fg = "#65bcff", bg = "NONE" },
+  LlmBlueLight = { fg = "#b0e2ff", bg = "NONE" },
+  LlmRedNormal = { fg = "#ff7eb9", bg = "NONE" },
+  LlmRedLight = { fg = "#fca7ea", bg = "NONE" },
+  LlmGreenNormal = { fg = "#4fd6be", bg = "NONE" },
+  LlmGreenLight = { fg = "#b8db87", bg = "NONE" },
+  LlmYellowNormal = { fg = "#ff966c", bg = "NONE" },
+  LlmYellowLight = { fg = "#f9e2af", bg = "NONE" },
+  LlmGrayNormal = { fg = "#828bb8", bg = "NONE" },
+  LlmGrayLight = { fg = "#9c9c9c", bg = "NONE" },
+  LlmPurpleNormal = { fg = "#c099ff", bg = "NONE" },
+  LlmPurpleLight = { fg = "#ee82ee", bg = "NONE" },
+  LlmWhiteNormal = { fg = "#c8d3f5", bg = "NONE" },
 }
 
 local llm_augroup = vim.api.nvim_create_augroup("llm_augroup", { clear = true })


### PR DESCRIPTION
- Add LlmSelection highlight, whose bg is identical to Cursorline.bg
- Add `default = true` to all Llm highlights

When customizing win_highlight og each window, `input` and `output` works fine, but due to the highlight of `models` and `history` window have LlmGrayLight overwrote, customizing will fail.

Now it works fine:

Here is my configuration and customized result:

![image](https://github.com/user-attachments/assets/8f5b2010-04fe-45bd-b863-fc2731ae358a)
```lua
-- existing configs
config = function()
    -- existing configs
    local winhighlight_input = "Normal:LLMPromptNormal,FloatTitle:TelescopePromptTitle"
    local winhighlight_output = "FloatTitle:TelescopeResultsTitle"
    local winhighlight_history = "FloatTitle:TelescopePreviewTitle"
    local winhighlight_models = "FloatTitle:TelescopePreviewMatch"
    chat_ui_opts = {
        relative = "editor",
	position = "50%",
	size = { width = "85%", height = "85%", },
	input = {
		float = {
                    border = { style = "solid", text = { top = Text(" User Input "), }, },
                    win_options = { winhighlight = winhighlight_input, },
		    size = { height = "10%", width = "80%" },
	        },
	},
	output = {
		float = {
                      border = { style = "solid", text = { top = Text(" Chat "), }, },
                      win_options = { winhighlight = winhighlight_output, },
		      size = { height = "90%", width = "80%" },
		},
	},
        history = {
                float = {
                    border = { style = "solid" },
                    win_options = { winhighlight = winhighlight_history, },
               },
        },
        models = {
                float = {
                      border = { style = "solid" },
                       win_options = { winhighlight = winhighlight_models, },
                },
        },
    },
 -- existing configs
```