### PR TITLE
Fix: remove line causing duplicate words in saved ollama chats

### DIFF
--- a/lua/llm/backends/ollama.lua
+++ b/lua/llm/backends/ollama.lua
@@ -29,7 +29,6 @@ function ollama.StreamingHandler(chunk, ctx)
       F.WriteContent(ctx.bufnr, ctx.winid, data.message.thinking)
     else
       backend_utils.mark_reason_end(ctx, true)
-      ctx.assistant_output = ctx.assistant_output .. data.message.content
       F.WriteContent(ctx.bufnr, ctx.winid, data.message.content)
     end
     ctx.line = ""

--- a/lua/llm/backends/ollama.lua
+++ b/lua/llm/backends/ollama.lua
@@ -19,7 +19,6 @@ function ollama.StreamingHandler(chunk, ctx)
       LOG:TRACE("json decode error:", data)
       return ctx.assistant_output
     end
-    ctx.assistant_output = ctx.assistant_output .. data.message.content
 
     -- add reasoning_content
     if F.IsValid(data.message.thinking) then
@@ -29,6 +28,7 @@ function ollama.StreamingHandler(chunk, ctx)
       F.WriteContent(ctx.bufnr, ctx.winid, data.message.thinking)
     else
       backend_utils.mark_reason_end(ctx, true)
+      ctx.assistant_output = ctx.assistant_output .. data.message.content
       F.WriteContent(ctx.bufnr, ctx.winid, data.message.content)
     end
     ctx.line = ""


### PR DESCRIPTION
Possible fix for #102 

I've found a fix that works for my use case, but I'm not very familiar with Lua, so I'm unsure if this is the correct way to solve it.